### PR TITLE
Fix default zsh plugin directory

### DIFF
--- a/scripts/install_zsh_plugins.sh
+++ b/scripts/install_zsh_plugins.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-# Check if ZSH_CUSTOM is set
+# Ensure ZSH_CUSTOM points to the Oh-My-Zsh custom directory
 if [ -z "$ZSH_CUSTOM" ]; then
-    echo "ZSH_CUSTOM is not set. Aborting..."
-    exit 1
+    ZSH_CUSTOM="$HOME/.oh-my-zsh/custom"
+    echo "ZSH_CUSTOM was not set. Defaulting to $ZSH_CUSTOM."
 else
     echo "ZSH_CUSTOM is set to $ZSH_CUSTOM."
 fi


### PR DESCRIPTION
## Summary
- default `ZSH_CUSTOM` when not set in `install_zsh_plugins.sh`

## Testing
- `bash -n scripts/install_zsh_plugins.sh`
- `bash -n dotfiles.sh`
- `bash -n scripts/install_essentials.sh`


------
https://chatgpt.com/codex/tasks/task_e_6841a072bf948325915ccef4ddd6c508